### PR TITLE
fix: handle missing keybindings.json and add test

### DIFF
--- a/src/snippets/keyBindings.test.ts
+++ b/src/snippets/keyBindings.test.ts
@@ -8,12 +8,15 @@ import { readSnippet } from '../snippets/updateSnippets';
 import { snippetBodyAsString } from '../utils/string';
 import type { Position } from 'vscode';
 import path from 'node:path';
+import { exists } from '../utils/fsInfo';
+import { writeFile } from 'node:fs/promises';
 
 vi.mock('../utils/profile');
 vi.mock('../utils/jsoncFilesIO');
 vi.mock('../snippets/updateSnippets.js');
 vi.mock('../utils/language');
 vi.mock('../utils/string');
+vi.mock('../utils/fsInfo');
 
 describe('keyBindings', () => {
 	describe('promptAddKeybinding', () => {
@@ -94,34 +97,19 @@ describe('keyBindings', () => {
 				},
 			]);
 		});
-	});
-			it('should create keybindings.json if it does not exist', async () => {
+		it('should create keybindings.json if it does not exist', async () => {
 			const item = new TreePathItem('my-snippet', 0, '/path/to/snippet.json');
 			const snippet = { prefix: 'p', body: 'b', scope: 'javascript' };
 			const keybindings: any[] = [];
 
-			// Mock fs helpers before calling the function
-			vi.mock('../utils/fsInfo', () => ({
-				exists: vi.fn().mockResolvedValue(false), 
-			}));
-			vi.mock('node:fs/promises', () => ({
-				writeFile: vi.fn().mockResolvedValue(undefined), 
-			}));
-
-			const { writeFile } = await import('node:fs/promises');
-			const { exists } = await import('../utils/fsInfo');
-
+			(exists as Mock).mockResolvedValue(false);
 			(getActiveProfilePath as Mock).mockResolvedValue('/profile');
 			(readSnippet as Mock).mockResolvedValue(snippet);
 			(readJsonC as Mock).mockResolvedValue(keybindings);
 
 			await promptAddKeybinding(item);
 
-			expect(writeFile).toHaveBeenCalledWith(
-				path.join('/profile/keybindings.json'),
-				'[]',
-				'utf-8'
-			);
+			expect(writeFile).toHaveBeenCalledWith(path.join('/profile/keybindings.json'), '[]', 'utf-8');
 		});
-
+	});
 });

--- a/src/snippets/keyBindings.ts
+++ b/src/snippets/keyBindings.ts
@@ -17,14 +17,13 @@ import type { VSCodeSnippet } from '../types';
 import { getCurrentLanguage } from '../utils/language';
 import { snippetBodyAsString } from '../utils/string';
 import { exists } from '../utils/fsInfo';
-import { writeFile } from 'node:fs/promises';
-
+import fs from 'node:fs/promises';
 
 /** Handler for the add keybindings commmand */
 async function promptAddKeybinding(item: TreePathItem) {
 	const keyBindPath = await getKeybindingsFilePath();
 	if (!(await exists(keyBindPath))) {
-		await writeFile(keyBindPath, '[]', 'utf-8');
+		await fs.writeFile(keyBindPath, '[]', 'utf-8');
 	}
 
 	const snippetTitle = item.description?.toString() ?? '';


### PR DESCRIPTION
Fixed a bug in `promptAddKeybinding` that caused a crash when `keybindings.json` did not exist.

## Summary
Fixed a bug in `promptAddKeybinding` that caused an error when `keybindings.json` did not exist.  
Added a file existence check and automatic creation of an empty JSON file when missing.  
Also added a test case to verify this behavior.

<!-- Optional: Link related issue(s) -->
Issue #:  #14

