### PR TITLE
Docs: add documentation for backup and restore snippets

### DIFF
--- a/docs/docs/snippet-management/backup-and-restore-snippets.md
+++ b/docs/docs/snippet-management/backup-and-restore-snippets.md
@@ -1,80 +1,47 @@
 ---
-id: backup-and-restore-snippets
-title: Backing Up and Restoring Snippets
-sidebar_position: 60
+title: Snippet Backups
+sidebar_label: Snippet Backups
+sidebar_position: 9
 ---
 
 This guide shows how to back up all your snippets and import them later using `.code-profile` files in VS Code with the SnippetStudio extension.
 
-### What is a .code-profile file?
+## What is a .code-profile file?
 
-A `.code-profile` file is a JSON document that can include settings, keybindings, extensions, and—importantly for us—snippets. SnippetStudio can extract the snippet content from a `.code-profile` and save it as standard VS Code snippet files (`.code-snippets` or language-scoped `.json`).
+A `.code-profile` file is a JSON document that can include settings, keybindings, extensions, and snippets. SnippetStudio can extract the snippet content and save it as standard VS Code snippet files.
 
-When SnippetStudio imports snippets from a `.code-profile`:
+When SnippetStudio imports snippets from this file:
 - It parses the `snippets` section.
-- It writes one or more `.code-snippets` files to a destination you choose.
-- If a snippet file is language-scoped (like `python.json`), it converts those into `.code-snippets` and assigns the language to `scope` automatically.
+- It writes all of the snippets files to a destination you choose.
 
----
-
-## Back up your snippets
-
-You can back up snippets using SnippetStudio’s export features:
-
-1. Open the command palette and run: `SnippetStudio: Export Snippet Files`.
-2. Choose where to save the exported `.code-snippets` files.
-3. Optionally commit these files to your dotfiles repo, store them in cloud storage, or embed them into a `.code-profile` you share.
-
-Tip: You can also extract snippets from installed extensions using `SnippetStudio: Copy Extension Snippets for Safe Editing`, then include those in your backup.
-
----
+VS Code has a built in command to [export](https://code.visualstudio.com/docs/configure/profiles#_export) one of your [profiles](https://code.visualstudio.com/docs/configure/profiles) to a .code-profile file.
 
 ## Import snippets from a .code-profile
 
 Use the dedicated command to read snippets from a `.code-profile` and write them into your VS Code snippets directory.
 
-1. Open the command palette and run: `SnippetStudio: Copy Snippets from .code-profile`.
+1. Open the command palette and run: **SnippetStudio: Copy Snippets from .code-profile**.
 2. Pick a source:
    - From profile template: Uses Microsoft’s official profile templates (e.g., Python, JavaScript) and fetches the profile from the VS Code CDN.
-   - From a gist: Prompts for a GitHub Gist ID and reads any `.code-profile` file(s) in that gist.
-   - From a file: Opens the file picker so you can select local `.code-profile` files.
-   - From a url: Fetches a raw `.code-profile` from a direct URL.
+   - From a gist: Prompts for a GitHub Gist ID and reads any .code-profile file(s) in that gist.
+   - From a file: Opens the file picker so you can select local .code-profile files.
+   - From a url: Fetches a raw .code-profile json from a direct URL.
 3. Choose where to save the imported snippets when prompted:
-   - Local (workspace `.vscode/`): Adds snippet files scoped to your current project.
+   - Local (workspace): Adds snippet files scoped to your current project.
    - Global (user profile): Adds snippet files to your active VS Code profile’s snippets directory.
+   - Downloads - Your downloads directory
 
-SnippetStudio will process the `.code-profile`, extract the `snippets` payload, and write the resulting `.code-snippets` files. If a filename already exists, it will generate a unique filename to avoid overwriting.
+SnippetStudio will process the .code-profile file, extract the snippets, and write the resulting snippet files. If a filename already exists, it will generate a unique filename to avoid overwriting.
 
----
-
-## Where can the .code-profile be read from?
+### Where can the .code-profile be read from?
 
 SnippetStudio supports multiple input locations:
 
-- File picker: Any `.code-profile` on your local filesystem.
-- GitHub Gist: Provide a Gist ID; SnippetStudio will import any `.code-profile` files found there.
-- URL: Paste a direct URL to the raw `.code-profile` file.
-- Built-in templates: Select an official profile template (e.g., `python`, `javascript`) which is fetched from the VS Code CDN.
-
-Destination options when saving imported snippets:
-- Local workspace: Stored under `.vscode/` in the current workspace.
-- Global user profile: Stored in your active VS Code profile’s snippets directory.
+- File picker: Any .code-profile on your local filesystem.
+- GitHub Gist: Provide a Gist ID; SnippetStudio will import any .code-profile files found there.
+- URL: Paste a direct URL to the raw .code-profile file.
+- Built-in templates: Select an official profile template (e.g., python, javascript) which is fetched from the VS Code CDN.
 
 ---
 
-## Example commands
-
-- `SnippetStudio: Copy Snippets from .code-profile`
-- `SnippetStudio: Export Snippet Files`
-- `SnippetStudio: Copy Extension Snippets for Safe Editing`
-
-If you prefer the keyboard, open the Command Palette (Ctrl/Cmd+Shift+P) and type the command names above.
-
----
-
-## Related links
-
-- VS Code Profiles documentation: [`https://code.visualstudio.com/docs/editor/profiles`](https://code.visualstudio.com/docs/editor/profiles)
-- SnippetStudio on VS Code Marketplace: [`https://marketplace.visualstudio.com/items?itemName=AlexDombroski.snippetstudio`](https://marketplace.visualstudio.com/items?itemName=AlexDombroski.snippetstudio)
-
-
+This command is good for importing code profile snippets without altering current snippets. Read [import](https://code.visualstudio.com/docs/configure/profiles#_import) to see the normal way of applying ALL parts of a VS Code profile. 


### PR DESCRIPTION
Fixes Issue #9 
- Added docs/docs/snippet-management/backup-and-restore-snippets.md
- Documents .code-profile usage to back up/import snippets with SnippetStudio
- Covers sources: built-in templates, gist, local file, URL
- Describes destinations: workspace .vscode/ and global user profile
- Includes example commands and links (VS Code Profiles, Marketplace)
- Sidebar autogenerates; page appears under Snippet Management

This contribution is part of Hacktoberfest 2025! 