### PR TITLE
research(textmate): added TextMate import/export PoC and conversion scr…

### DIFF
--- a/research/textmate/import-to-textmate.md
+++ b/research/textmate/import-to-textmate.md
@@ -1,0 +1,66 @@
+# TextMate snippet import/export — Proof of Concept
+
+This document covers a small PoC for importing/exporting snippets between VS Code and TextMate. It answers where TextMate stores snippets, how to handle interpolated shell code in snippet bodies, and includes two conversion scripts: VS Code -> TextMate and TextMate -> VS Code.
+
+## 1. Where TextMate stores snippets
+
+TextMate uses bundles to organize snippets. User snippets are usually stored in the `Application Support` area or in Bundles in `~/Library/Application Support/Avian/` (older paths) or as part of a TextMate bundle in `~/Library/Application Support/Avian/Bundles/` or `~/Library/Application Support/TextMate/` depending on TextMate version. However, there is not a single canonical, always-present path across versions; TextMate 2 also supports user bundles in `~/Library/Application Support/Avian/Bundles`.
+
+A more reliable approach is to use TextMate’s `tmProperties` and bundle structure, or place snippets in a user bundle at a location like:
+
+- ~/Library/Application Support/Avian/Bundles/User.tmbundle/Snippets/
+
+Each TextMate snippet is usually stored as a `.tmSnippet` file (XML plist) inside a bundle's `Snippets` folder, or inside a JSON/PLIST within the bundle. Because of this variability, an importer/exporter should allow specifying the target directory rather than assuming a single path.
+
+## 2. TextMate snippet file format
+
+A `.tmSnippet` file is an XML plist (similar to Xcode `.codesnippet`) with keys like:
+
+- `content` — snippet body
+- `name` — title
+- `tabTrigger` — trigger
+- `scope` — scope selector (like source.python)
+- `uuid` — optional identifier
+
+Example minimal `.tmSnippet` (plist XML) keys are covered in the scripts below.
+
+## 3. Stripping interpolated shell code from JSON
+
+VS Code snippets may include interpolated shell code (e.g., placeholders that execute shell snippets, or snippet variables like `$TM_SELECTED_TEXT` or `${exec:...}` — sometimes in extension-generated snippets). To make safe conversions we can:
+
+- Remove or replace patterns like `${exec:...}` or `${command:...}` with a simple placeholder or empty string.
+- Remove backtick-wrapped interpolated shell code (e.g., `` `...` ``) if present inside the snippet body.
+- Convert placeholders like `${1:name}` to TextMate/TabStop syntax if necessary (TextMate uses `TM_TAB_TRIGGER` / `$1` style placeholders). A conservative approach is to keep `$1`, `$2`, etc.
+
+The provided scripts perform a best-effort sanitization by removing `${exec:...}` and `${command:...}` constructs and stripping inline backtick shell expressions.
+
+## 4. Scripts included (PoC)
+
+- `vscodeToTextMate.js` — reads a VS Code snippet JSON file (one or many snippets), converts each snippet into a `.tmSnippet` plist file, and writes them to an output directory.
+- `textMateToVscode.js` — reads `.tmSnippet` files from a directory and converts them into a single VS Code snippets JSON object written to stdout or a file.
+
+Both scripts are minimal, synchronous, and designed for PoC. They perform simple sanitization of exec/command placeholders and inline shell code.
+
+## 5. Usage examples
+
+- Convert VS Code snippets to TextMate snippets (writes to `./out`):
+
+```bash
+node research/textmate/vscodeToTextMate.js path/to/vscode-snippets.json ./out
+```
+
+- Convert a TextMate bundle snippets directory to a VS Code snippets file:
+
+```bash
+node research/textmate/textMateToVscode.js path/to/snippets/ > vscode-snippets.json
+```
+
+## 6. Next steps
+
+- Add careful placeholder conversion tests (VS Code <> TextMate placeholder syntax differences).
+- Add support for scope mapping between languages.
+- Add unit tests and a sample fixture bundle.
+
+---
+
+Proof-of-concept added by Snippet Studio research notes.

--- a/research/textmate/textMateToVscode.js
+++ b/research/textmate/textMateToVscode.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// textMateToVscode.js
+// Read .tmSnippet plist files from a directory and output a VS Code snippets JSON
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function plutilToJson(filePath) {
+  const res = spawnSync('plutil', ['-convert', 'json', '-o', '-', filePath], { encoding: 'utf8' });
+  if (res.error) throw res.error;
+  if (res.status !== 0) throw new Error(res.stderr || 'plutil failed');
+  return JSON.parse(res.stdout);
+}
+
+function tmToVscode(snippetObj) {
+  const name = snippetObj.name || snippetObj['title'];
+  const body = snippetObj.content || '';
+  const tabTrigger = snippetObj.tabTrigger || snippetObj['tabTrigger'] || null;
+  const scope = (snippetObj.scope && Array.isArray(snippetObj.scope) && snippetObj.scope[0]) || snippetObj.scope || null;
+  return {
+    title: name,
+    prefix: tabTrigger,
+    body: body.split('\n'),
+    description: snippetObj.description || null,
+    scope
+  };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const dir = argv[0] || path.join(require('os').homedir(), 'Library/Application Support/Avian/Bundles/User.tmbundle/Snippets');
+
+  if (!fs.existsSync(dir)) {
+    console.error('Directory does not exist:', dir);
+    process.exit(2);
+  }
+
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.tmSnippet'));
+  if (files.length === 0) {
+    console.error('No .tmSnippet files found in', dir);
+    process.exit(2);
+  }
+
+  const out = {};
+  for (const f of files) {
+    try {
+      const json = plutilToJson(path.join(dir, f));
+      const entry = tmToVscode(json);
+      const key = (entry.title || f).replace(/\s+/g, '-').replace(/[^a-z0-9-_.]/gi, '');
+      out[key] = entry;
+    } catch (err) {
+      console.error('Failed to parse', f, err.message);
+    }
+  }
+
+  console.log(JSON.stringify(out, null, 2));
+}
+
+if (require.main === module) main();

--- a/research/textmate/vscodeToTextMate.js
+++ b/research/textmate/vscodeToTextMate.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// vscodeToTextMate.js
+// Read a VS Code snippets JSON file and write TextMate .tmSnippet plist files
+
+const fs = require('fs');
+const path = require('path');
+
+function sanitizeBody(body) {
+  if (!body) return '';
+  // remove ${exec:...} and ${command:...}
+  body = body.replace(/\$\{\s*(?:exec|command)\s*:[^}]*\}/g, '');
+  // remove inline backtick shell code `...`
+  body = body.replace(/`([^`]*)`/g, '');
+  return body;
+}
+
+function escapeXml(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildTmSnippet({ name, tabTrigger, scope, content, uuid }) {
+  const c = escapeXml(content);
+  const n = escapeXml(name || 'Snippet');
+  const t = tabTrigger ? `<string>${escapeXml(tabTrigger)}</string>` : '';
+  const s = scope ? `<string>${escapeXml(scope)}</string>` : '';
+  const u = uuid ? `<string>${escapeXml(uuid)}</string>` : '';
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n  <key>content</key>\n  <string>${c}</string>\n  <key>name</key>\n  <string>${n}</string>\n  ${t ? `<key>tabTrigger</key>\n  ${t}` : ''}\n  ${s ? `<key>scope</key>\n  <array>\n    ${s}\n  </array>` : ''}\n  ${u ? `<key>uuid</key>\n  ${u}` : ''}\n</dict>\n</plist>\n`;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length < 1) {
+    console.error('Usage: node vscodeToTextMate.js <vscode-snippets.json> [outdir]');
+    process.exit(2);
+  }
+  const inFile = argv[0];
+  const outDir = path.resolve(process.cwd(), argv[1] || './out');
+
+  if (!fs.existsSync(inFile)) {
+    console.error('Input file not found:', inFile);
+    process.exit(2);
+  }
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+  const data = JSON.parse(fs.readFileSync(inFile, 'utf8'));
+  for (const [key, snippet] of Object.entries(data)) {
+    const name = snippet.title || key;
+    const tabTrigger = snippet.prefix || snippet['prefix'];
+    const scope = snippet.scope || null;
+    const body = Array.isArray(snippet.body) ? snippet.body.join('\n') : snippet.body || '';
+    const sanitized = sanitizeBody(body);
+    const xml = buildTmSnippet({ name, tabTrigger, scope, content: sanitized, uuid: null });
+    const filename = `${key.replace(/[^a-z0-9-_]/gi, '-')}.tmSnippet`;
+    fs.writeFileSync(path.join(outDir, filename), xml, 'utf8');
+    console.log('Wrote', filename);
+  }
+}
+
+if (require.main === module) main();


### PR DESCRIPTION
This PR adds a textmate.md file within the research/textmate folder detailing a proof of concept for creating a new command to export snippets to Textmate, or import snippets from Textmate.

Questions to Answer
Is there a consistent filepath where snippets are stored in Textmate?
How can we strip Interpolated Shell Code from the JSON?

 Scripts to Write
 Script to read a VS Code snippet and write it to a new file as a Textmate snippet
(There may not be any format changes required)
 Script to read a Textmate snippet and export it as a VS Code snippet.

Context
This is part of the ongoing “Export Snippets to Other IDEs” discussion aimed at supporting multiple editors seamlessly.
Issue #26 
