### PR TITLE
feat(test): add locate snippet paths tests

### DIFF
--- a/src/git/extensionsGithub.test.ts
+++ b/src/git/extensionsGithub.test.ts
@@ -7,7 +7,7 @@ import vscode, { showInformationMessage, showQuickPick } from '../vscode';
 import { chooseLocalGlobal, getFileName } from '../utils/user';
 import type { Octokit } from '@octokit/core' with { 'resolution-mode': 'import' };
 
-const { __fileTextRequest, __folderRequest, importBuiltinExtension } = extensionsGithub;
+const { _fileTextRequest, _folderRequest, importBuiltinExtension } = extensionsGithub;
 
 vi.mock('../utils/jsoncFilesIO', async () => {
 	const mod = await vi.importActual('../utils/jsoncFilesIO');
@@ -61,20 +61,20 @@ describe.skipIf(!process.env.GITHUB_TOKEN)('extensionsGithub', () => {
 
 	describe.concurrent('folderRequest', () => {
 		it.concurrent('should return data if response is an array', async () => {
-			const result = await __folderRequest(client, '');
+			const result = await _folderRequest(client, '');
 			const names = result?.map((i) => i.name);
 			expect(names).toContain('LICENSE.txt');
 			expect(names).toContain('README.md');
 		});
 
 		it.concurrent("will throw if the path doesn't exist", async () => {
-			await expect(__folderRequest(client, 'foo/bar')).rejects.toThrow();
+			await expect(_folderRequest(client, 'foo/bar')).rejects.toThrow();
 		});
 	});
 
 	describe.concurrent('fileTextRequest', () => {
 		it.concurrent('should return decoded text content', async () => {
-			const result = await __fileTextRequest(client, 'LICENSE.txt');
+			const result = await _fileTextRequest(client, 'LICENSE.txt');
 			expect(result).toContain('MIT License');
 		});
 	});

--- a/src/git/extensionsGithub.ts
+++ b/src/git/extensionsGithub.ts
@@ -41,8 +41,8 @@ export async function importBuiltinExtension(context: ExtensionContext) {
 
 	for (const selection of selections) {
 		const [snippetFiles, pkgContent] = await Promise.all([
-			__folderRequest(client, `extensions/${selection.label}/snippets`),
-			__fileTextRequest(client, `extensions/${selection.label}/package.json`),
+			_folderRequest(client, `extensions/${selection.label}/snippets`),
+			_fileTextRequest(client, `extensions/${selection.label}/package.json`),
 		]);
 
 		if (snippetFiles === undefined) {
@@ -59,7 +59,7 @@ export async function importBuiltinExtension(context: ExtensionContext) {
 
 		const snippetContents = await Promise.all(
 			verifiedSnippetFiles.map((file) =>
-				__fileTextRequest(client, `extensions/${selection.label}/snippets/${file.name}`)
+				_fileTextRequest(client, `extensions/${selection.label}/snippets/${file.name}`)
 			)
 		);
 
@@ -90,7 +90,7 @@ export async function importBuiltinExtension(context: ExtensionContext) {
 
 /** finds all extension folders with snippets within the vscode repo */
 export async function __getDirsWithSnippets(client: Octokit) {
-	const res = await __folderRequest(client, 'extensions');
+	const res = await _folderRequest(client, 'extensions');
 	const folders = res?.filter((item) => item.type === 'dir') ?? [];
 
 	const extFolders = Array(folders.length);
@@ -115,7 +115,7 @@ export async function __getDirsWithSnippets(client: Octokit) {
 						increment: (1 / extFolders.length) * 100,
 					});
 
-					const subItems = await __folderRequest(client, `extensions/${folder.name}`);
+					const subItems = await _folderRequest(client, `extensions/${folder.name}`);
 
 					const hasSnippets = subItems?.some(
 						(item) => item.type === 'dir' && item.name === 'snippets'
@@ -143,7 +143,7 @@ export async function __getDirsWithSnippets(client: Octokit) {
 }
 
 /** gets folder contents within vscode repo */
-export async function __folderRequest(client: Octokit, fp: string) {
+export async function _folderRequest(client: Octokit, fp: string) {
 	const { data } = await client.request('GET /repos/{owner}/{repo}/contents/{path}', {
 		owner: 'microsoft',
 		repo: 'vscode',
@@ -155,7 +155,7 @@ export async function __folderRequest(client: Octokit, fp: string) {
 }
 
 /** gets text content within vscode repo */
-export async function __fileTextRequest(client: Octokit, path: string): Promise<string> {
+export async function _fileTextRequest(client: Octokit, path: string): Promise<string> {
 	const { data }: any = await client.request('GET /repos/{owner}/{repo}/contents/{path}', {
 		owner: 'microsoft',
 		repo: 'vscode',

--- a/src/snippets/codeProfile.test.ts
+++ b/src/snippets/codeProfile.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, type Mock } from 'vitest';
-import { __fromBuiltIn, __fromGist, __fromUrl, importCodeProfileSnippets } from './codeProfile';
+import { _fromBuiltIn, _fromGist, _fromUrl, importCodeProfileSnippets } from './codeProfile';
 import { showInformationMessage, showInputBox, showQuickPick } from '../vscode';
 import fs from 'node:fs/promises';
 import https from 'node:https';
@@ -56,7 +56,7 @@ describe.concurrent('codeProfile', () => {
 				const gistIdWithNoSnippets = 'ddac491daeff48c5f1346ba2960462fa';
 				(getGistId as Mock).mockReturnValue(gistIdWithNoSnippets);
 
-				await __fromGist(context);
+				await _fromGist(context);
 
 				expect(showInformationMessage).toBeCalled();
 			}
@@ -70,7 +70,7 @@ describe.concurrent('codeProfile', () => {
 			(showInputBox as Mock).mockResolvedValue(url);
 			mockHttps();
 
-			await __fromUrl();
+			await _fromUrl();
 			expect(https.get).toBeCalledWith(url, expect.any(Function));
 		});
 	});
@@ -80,14 +80,14 @@ describe.concurrent('codeProfile', () => {
 			(showQuickPick as Mock).mockReturnValue({ label: 'python' });
 			mockHttps();
 
-			await __fromBuiltIn();
+			await _fromBuiltIn();
 			expect(https.get).toBeCalledWith(expect.stringContaining('python'), expect.any(Function));
 		});
 		it('should cancel if no template is selected', async () => {
 			(showQuickPick as Mock).mockReturnValue(undefined);
 			mockHttps();
 
-			await __fromBuiltIn();
+			await _fromBuiltIn();
 			expect(https.get).not.toBeCalled();
 		});
 	});

--- a/src/snippets/codeProfile.ts
+++ b/src/snippets/codeProfile.ts
@@ -18,22 +18,22 @@ export async function importCodeProfileSnippets(context: ExtensionContext) {
 		{
 			label: 'From profile template',
 			description: 'snippets typically created from a vscode profile template',
-			run: __fromBuiltIn,
+			run: _fromBuiltIn,
 		},
 		{
 			label: 'From a gist',
 			description: 'import snippets from a .code-profile file from a gist',
-			run: () => __fromGist(context),
+			run: () => _fromGist(context),
 		},
 		{
 			label: 'From a file',
 			description: 'choose a .code-profile file in your file manager',
-			run: fromFile,
+			run: _fromFile,
 		},
 		{
 			label: 'From a url',
 			description: 'fetch the .code-profile file raw from a url',
-			run: __fromUrl,
+			run: _fromUrl,
 		},
 	];
 	const selection = await showQuickPick(items, {
@@ -92,7 +92,7 @@ async function saveCodeProfiles(
 // ------------------------------ Get Code Profile File Content ------------------------------
 
 /** pick a .code-profile file via file expolorer and  */
-async function fromFile(): Promise<string[] | undefined> {
+async function _fromFile(): Promise<string[] | undefined> {
 	const uris = await showOpenDialog({
 		canSelectFiles: true,
 		canSelectFolders: false,
@@ -119,7 +119,7 @@ async function fromFile(): Promise<string[] | undefined> {
 }
 
 /** attempts to reads a .code-profile from a gist */
-export async function __fromGist(context: ExtensionContext): Promise<string[] | undefined> {
+export async function _fromGist(context: ExtensionContext): Promise<string[] | undefined> {
 	const { getGistId } = await import('../git/utils.js');
 	const gistId = await getGistId();
 	if (gistId === undefined) {
@@ -143,7 +143,7 @@ export async function __fromGist(context: ExtensionContext): Promise<string[] | 
 }
 
 /** gets the snippets from Microsoft's template code profiles */
-export async function __fromBuiltIn(): Promise<string[] | undefined> {
+export async function _fromBuiltIn(): Promise<string[] | undefined> {
 	const validProfiles = [
 		'python',
 		// 'angular',
@@ -168,7 +168,7 @@ export async function __fromBuiltIn(): Promise<string[] | undefined> {
 }
 
 /** gets file from user  code profile from a url with the raw file */
-export async function __fromUrl(): Promise<string[] | undefined> {
+export async function _fromUrl(): Promise<string[] | undefined> {
 	const url = await showInputBox({
 		title: 'Paste a URL to a raw .code-snippets file',
 	});

--- a/src/snippets/extension/locate.test.ts
+++ b/src/snippets/extension/locate.test.ts
@@ -8,7 +8,7 @@ import {
 	findAllExtensionSnippetsFiles,
 	flattenScopedExtensionSnippets,
 	getExtensionSnippetLangs,
-	__getExtensionsDirPath,
+	_getExtensionsDirPath,
 } from './locate';
 import vscode from '../../vscode';
 
@@ -150,23 +150,23 @@ describe('locate', () => {
 			Object.defineProperty(vscode.env, 'appName', { value: 'Visual Studio Code' });
 		});
 		it('should find the vscode extensions folder', () => {
-			expect(__getExtensionsDirPath()).toBe(configPath`.vscode`);
+			expect(_getExtensionsDirPath()).toBe(configPath`.vscode`);
 		});
 		it('should should update the path for the nightly build', () => {
 			Object.defineProperty(vscode.env, 'appName', { value: 'Visual Studio Code - Insiders' });
-			expect(__getExtensionsDirPath()).toBe(configPath`.vscode-insiders`);
+			expect(_getExtensionsDirPath()).toBe(configPath`.vscode-insiders`);
 		});
 		it('should should update the path for VSCodium', () => {
 			Object.defineProperty(vscode.env, 'appName', { value: 'VSCodium' });
-			expect(__getExtensionsDirPath()).toBe(configPath`.vscode-oss`);
+			expect(_getExtensionsDirPath()).toBe(configPath`.vscode-oss`);
 		});
 		it('should should update the path for Cursor', () => {
 			Object.defineProperty(vscode.env, 'appName', { value: 'Cursor' });
-			expect(__getExtensionsDirPath()).toBe(configPath`.cursor`);
+			expect(_getExtensionsDirPath()).toBe(configPath`.cursor`);
 		});
 		it('should default to VS Code', () => {
 			Object.defineProperty(vscode.env, 'appName', { value: 'Windsurf' });
-			expect(__getExtensionsDirPath()).toBe(configPath`.vscode`);
+			expect(_getExtensionsDirPath()).toBe(configPath`.vscode`);
 		});
 	});
 });

--- a/src/snippets/extension/locate.ts
+++ b/src/snippets/extension/locate.ts
@@ -20,7 +20,7 @@ import { exists } from '../../utils/fsInfo';
 import vscode from '../../vscode';
 
 /** returns the location of downloaded extensions for current platform and os */
-export function __getExtensionsDirPath(): string {
+export function _getExtensionsDirPath(): string {
 	const appConfigs: Record<string, string> = {
 		'Visual Studio Code': '.vscode',
 		'Visual Studio Code - Insiders': '.vscode-insiders',
@@ -33,7 +33,7 @@ export function __getExtensionsDirPath(): string {
 
 /** given the path of an extension snippet file, return the package.json contribution path */
 function getPackagePathFromSnippetPath(snippetPath: string): string {
-	const extDirPath = __getExtensionsDirPath();
+	const extDirPath = _getExtensionsDirPath();
 	const relative = path.relative(extDirPath, snippetPath);
 	const extensionFolder = relative.split(path.sep)[0];
 	return path.join(extDirPath, extensionFolder, 'package.json');
@@ -73,7 +73,7 @@ export function flattenScopedExtensionSnippets(
 
 /** finds all extension snippet files and groups them by extension */
 export async function findAllExtensionSnippetsFiles(): Promise<ExtensionSnippetFilesMap> {
-	const dir = __getExtensionsDirPath();
+	const dir = _getExtensionsDirPath();
 	if (!(await exists(dir))) {
 		return {};
 	}

--- a/src/snippets/locateSnippets.test.ts
+++ b/src/snippets/locateSnippets.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, type Mock, beforeEach } from 'vitest';
 import fs from 'node:fs/promises';
 import {
-	__getGlobalLangSnippetFiles,
+	_getGlobalLangSnippetFiles,
 	findCodeSnippetsFiles,
 	locateAllSnippetFiles,
 	locateSnippetFiles,
@@ -35,10 +35,7 @@ describe('locateSnippets', () => {
 	describe('locateSnippetFiles', () => {
 		beforeEach(() => {
 			(exists as Mock).mockResolvedValue(true);
-			(fs.readdir as Mock).mockResolvedValue([
-				'favorites.code-snippets',
-				'other-language.json',
-			]);
+			(fs.readdir as Mock).mockResolvedValue(['favorites.code-snippets', 'other-language.json']);
 			(getCurrentLanguage as Mock).mockReturnValue('python');
 		});
 		it('should find snippets files of the current language', async () => {
@@ -69,7 +66,7 @@ describe('locateSnippets', () => {
 				'typescript.json',
 				'python.json',
 			]);
-			const files = await __getGlobalLangSnippetFiles('/global/path', 'typescript');
+			const files = await _getGlobalLangSnippetFiles('/global/path', 'typescript');
 			expect(files.length).toBe(2);
 		});
 	});

--- a/src/snippets/locateSnippets.ts
+++ b/src/snippets/locateSnippets.ts
@@ -26,7 +26,7 @@ async function locateSnippetFiles(langId?: string): Promise<string[]> {
 		: [await getActiveProfileSnippetsDir()];
 
 	const globalTasks = globalDirs.map((dir) => {
-		return __getGlobalLangSnippetFiles(dir, langId);
+		return _getGlobalLangSnippetFiles(dir, langId);
 	});
 
 	const localTask = (async () => {
@@ -44,7 +44,7 @@ async function locateSnippetFiles(langId?: string): Promise<string[]> {
  * Searches and finds the global snippets file for a given language.
  * @returns returns a global snippet filepath, or empty string if couldn't find it.
  */
-export async function __getGlobalLangSnippetFiles(
+export async function _getGlobalLangSnippetFiles(
 	globalSnippetsPath: string,
 	langId?: string
 ): Promise<string[]> {

--- a/src/ui/LocationTreeProvider.test.ts
+++ b/src/ui/LocationTreeProvider.test.ts
@@ -85,7 +85,7 @@ describe('ui/LocationTreeProvider', () => {
 
 	it('should debounce refresh calls', async () => {
 		vi.useFakeTimers();
-		const refreshSpy = vi.spyOn(provider, '__refresh');
+		const refreshSpy = vi.spyOn(provider, '_refresh');
 
 		provider.debounceRefresh();
 		provider.debounceRefresh();

--- a/src/ui/LocationTreeProvider.ts
+++ b/src/ui/LocationTreeProvider.ts
@@ -23,13 +23,13 @@ export default class LocationTreeProvider implements TreeDataProvider<TreeItem> 
 	// ---------- Constructor ---------- //
 
 	constructor() {
-		this.__refresh();
+		this._refresh();
 	}
 
 	// ---------- Refresh Methods ---------- //
 
 	/** finds all snippet files and redisplays them */
-	async __refresh() {
+	async _refresh() {
 		const [locals, globals, profiles] = await locateAllSnippetFiles();
 		this.localTreeItems = locals.map((p) => snippetLocationTemplate(p));
 		const links = await getLinkedSnippets();
@@ -75,7 +75,7 @@ export default class LocationTreeProvider implements TreeDataProvider<TreeItem> 
 			clearTimeout(this.debounceTimer); // Clear previous timer
 		}
 		this.debounceTimer = setTimeout(async () => {
-			await this.__refresh(); // Call __refresh after delay
+			await this._refresh(); // Call _refresh after delay
 			this.debounceTimer = undefined; // Clear timer
 		}, 400); // Adjust delay as needed (e.g., 200ms)
 	}

--- a/src/ui/editor/SnippetEditorProvider.test.ts
+++ b/src/ui/editor/SnippetEditorProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
-import SnippetEditorProvider, { __escapeDollarSignIfNeeded } from './SnippetEditorProvider';
+import SnippetEditorProvider, { _escapeDollarSignIfNeeded } from './SnippetEditorProvider';
 import SnippetDataManager from './SnippetDataManager';
 import type { Position as PositionType, TextEditor } from 'vscode';
 import vscode, { Position, getConfiguration, onDidChangeActiveTextEditor } from '../../vscode';
@@ -135,14 +135,14 @@ describe('SnippetEditorProvider', () => {
 		it('should auto-escape dollar signs when enabled', async () => {
 			provider.handleDocumentChange(changeEvent);
 
-			const newText = __escapeDollarSignIfNeeded('const a = $1', 11);
+			const newText = _escapeDollarSignIfNeeded('const a = $1', 11);
 			expect(newText).toBe('const a = \\$1');
 		});
 
 		it('should not auto-escape dollar signs when disabled', async () => {
 			provider.handleDocumentChange(changeEvent);
 
-			const newText = __escapeDollarSignIfNeeded('const a = ${4:placeholder}', 11);
+			const newText = _escapeDollarSignIfNeeded('const a = ${4:placeholder}', 11);
 			expect(newText).toBe('const a = \\${4:placeholder}');
 		});
 	});

--- a/src/ui/editor/SnippetEditorProvider.ts
+++ b/src/ui/editor/SnippetEditorProvider.ts
@@ -67,10 +67,7 @@ export default class SnippetEditorProvider implements FileSystemProvider {
 			change.text <= '9' &&
 			getConfiguration('snippetstudio').get<boolean>('editor.autoEscapeDollarSigns')
 		) {
-			const newText = __escapeDollarSignIfNeeded(
-				changeEvent.document.getText(),
-				change.rangeOffset
-			);
+			const newText = _escapeDollarSignIfNeeded(changeEvent.document.getText(), change.rangeOffset);
 
 			if (newText === undefined) {
 				return;
@@ -229,7 +226,7 @@ export default class SnippetEditorProvider implements FileSystemProvider {
  * @param offset the position of the number inside the potential tabstop/placeholder/choice
  * @returns the updated text or undefined if nothing changed
  */
-export function __escapeDollarSignIfNeeded(text: string, offset: number): string | undefined {
+export function _escapeDollarSignIfNeeded(text: string, offset: number): string | undefined {
 	const testText = text.slice(offset - 2, offset);
 
 	if (/\$$/.test(testText)) {

--- a/src/ui/editor/snippetEditor.test.ts
+++ b/src/ui/editor/snippetEditor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, type Mock, type Mocked } from 'vitest';
-import initSnippetEditorCommands, { __saveSnippet } from './snippetEditor';
+import initSnippetEditorCommands, { _saveSnippet } from './snippetEditor';
 import vscode, {
 	executeCommand,
 	onDidChangeActiveTextEditor,
@@ -46,7 +46,7 @@ describe('saveSnippet', () => {
 			document: { uri: { scheme: 'file' } as Uri } as TextDocument,
 		} as TextEditor);
 
-		await __saveSnippet(mockEditor);
+		await _saveSnippet(mockEditor);
 		expect(mockEditor.getSnippetData).not.toHaveBeenCalled();
 	});
 
@@ -57,7 +57,7 @@ describe('saveSnippet', () => {
 
 		(mockEditor.getSnippetData as Mock).mockReturnValue(undefined);
 
-		await __saveSnippet(mockEditor);
+		await _saveSnippet(mockEditor);
 		expect(showErrorMessage).toHaveBeenCalled();
 	});
 
@@ -77,7 +77,7 @@ describe('saveSnippet', () => {
 			description: 'example snippet',
 		});
 
-		await __saveSnippet(mockEditor);
+		await _saveSnippet(mockEditor);
 		expect(writeSnippet).toHaveBeenCalled();
 		expect(executeCommand).toHaveBeenCalledTimes(3);
 	});

--- a/src/ui/editor/snippetEditor.ts
+++ b/src/ui/editor/snippetEditor.ts
@@ -15,7 +15,7 @@ import { titleCase } from '../../utils/string';
 function initSnippetEditorCommands(context: ExtensionContext, provider: SnippetEditorProvider) {
 	context.subscriptions.push(
 		registerCommand('snippetstudio.editor.save', async () => {
-			await __saveSnippet(provider);
+			await _saveSnippet(provider);
 		}),
 		registerCommand('snippetstudio.editor.cancel', () => {
 			const uri = getCurrentUri();
@@ -45,7 +45,7 @@ function initSnippetEditorCommands(context: ExtensionContext, provider: SnippetE
 }
 
 /** saves a snippet and closes the editor */
-export async function __saveSnippet(provider: SnippetEditorProvider) {
+export async function _saveSnippet(provider: SnippetEditorProvider) {
 	const editor = vscode.window.activeTextEditor;
 	if (editor?.document.uri.scheme !== 'snippetstudio') {
 		return;

--- a/src/ui/editor/snippetFeatures.test.ts
+++ b/src/ui/editor/snippetFeatures.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, type Mock, type Mocked } from 'vitest';
 import initSnippetFeatureCommands, {
-	__getNextFeatureNumber,
-	__showVariableQuickPick,
-	__variableList,
+	_getNextFeatureNumber,
+	_showVariableQuickPick,
+	_variableList,
 } from './snippetFeatures';
 import vscode, {
 	getConfiguration,
@@ -106,7 +106,7 @@ describe('initSnippetFeatureCommands', () => {
 	});
 });
 
-describe('__getNextFeatureNumber', () => {
+describe('getNextFeatureNumber', () => {
 	let mockEditor: TextEditor;
 
 	beforeEach(() => {
@@ -120,31 +120,31 @@ describe('__getNextFeatureNumber', () => {
 	it('should start at 1 for an empty document', () => {
 		(mockEditor.document.getText as Mock).mockReturnValue('');
 		(getConfiguration as Mock).mockReturnValue({ get: vi.fn().mockReturnValue(true) });
-		expect(__getNextFeatureNumber(mockEditor)).toBe(1);
+		expect(_getNextFeatureNumber(mockEditor)).toBe(1);
 	});
 
 	it('should find the next available number', () => {
 		(mockEditor.document.getText as Mock).mockReturnValue('const a = ${1:foo}; const b = $2;');
 		(getConfiguration as Mock).mockReturnValue({ get: vi.fn().mockReturnValue(true) });
-		expect(__getNextFeatureNumber(mockEditor)).toBe(3);
+		expect(_getNextFeatureNumber(mockEditor)).toBe(3);
 	});
 
 	it('should ignore escaped dollar signs', () => {
 		(mockEditor.document.getText as Mock).mockReturnValue('const a = \\${1:foo};');
 		(getConfiguration as Mock).mockReturnValue({ get: vi.fn().mockReturnValue(true) });
-		expect(__getNextFeatureNumber(mockEditor)).toBe(1);
+		expect(_getNextFeatureNumber(mockEditor)).toBe(1);
 	});
 
 	it('should return a snippet placeholder if autoFill is off', () => {
 		(mockEditor.document.getText as Mock).mockReturnValue('');
 		(getConfiguration as Mock).mockReturnValue({ get: vi.fn().mockReturnValue(false) });
-		expect(__getNextFeatureNumber(mockEditor)).toBe('${1:1}');
+		expect(_getNextFeatureNumber(mockEditor)).toBe('${1:1}');
 	});
 });
 
-describe('__variableList', () => {
+describe('variableList', () => {
 	it('should return a comma-separated string of variables', () => {
-		const list = __variableList();
+		const list = _variableList();
 		expect(typeof list).toBe('string');
 		expect(list).toContain('TM_SELECTED_TEXT');
 		expect(list).toContain('LINE_COMMENT');
@@ -152,17 +152,17 @@ describe('__variableList', () => {
 	});
 });
 
-describe('__showVariableQuickPick', () => {
+describe('showVariableQuickPick', () => {
 	it('should show quick pick and return selected label', async () => {
 		(showQuickPick as Mock).mockResolvedValue({ label: 'TM_CURRENT_LINE' });
-		const result = await __showVariableQuickPick();
+		const result = await _showVariableQuickPick();
 		expect(showQuickPick).toHaveBeenCalled();
 		expect(result).toBe('TM_CURRENT_LINE');
 	});
 
 	it('should return undefined if nothing is selected', async () => {
 		(showQuickPick as Mock).mockResolvedValue(undefined);
-		const result = await __showVariableQuickPick();
+		const result = await _showVariableQuickPick();
 		expect(result).toBeUndefined();
 	});
 });

--- a/src/ui/editor/snippetFeatures.ts
+++ b/src/ui/editor/snippetFeatures.ts
@@ -25,7 +25,7 @@ export default function initSnippetFeatureCommands(
 			// eslint-disable-next-line no-unused-vars
 			(editor: TextEditor, edit: TextEditorEdit) => {
 				editor.insertSnippet(
-					new SnippetString(`\\\$${__getNextFeatureNumber(editor)}$0`),
+					new SnippetString(`\\\$${_getNextFeatureNumber(editor)}$0`),
 					editor.selection
 				);
 			}
@@ -36,7 +36,7 @@ export default function initSnippetFeatureCommands(
 			(editor: TextEditor, edit: TextEditorEdit) => {
 				editor.insertSnippet(
 					new SnippetString(
-						`\\\${${__getNextFeatureNumber(editor)}:\${2:\${TM_SELECTED_TEXT:placeholder}}}$0`
+						`\\\${${_getNextFeatureNumber(editor)}:\${2:\${TM_SELECTED_TEXT:placeholder}}}$0`
 					),
 					editor.selection
 				);
@@ -48,7 +48,7 @@ export default function initSnippetFeatureCommands(
 			(editor: TextEditor, edit: TextEditorEdit) => {
 				editor.insertSnippet(
 					new SnippetString(
-						`\\\${${__getNextFeatureNumber(editor)}|\${2:\${TM_SELECTED_TEXT:choice}},\${3:choice}|}$0`
+						`\\\${${_getNextFeatureNumber(editor)}|\${2:\${TM_SELECTED_TEXT:choice}},\${3:choice}|}$0`
 					),
 					editor.selection
 				);
@@ -63,7 +63,7 @@ export default function initSnippetFeatureCommands(
 				'snippetstudio.editor.insertVariable',
 				// eslint-disable-next-line no-unused-vars
 				async (editor: TextEditor, edit: TextEditorEdit) => {
-					const variable = await __showVariableQuickPick();
+					const variable = await _showVariableQuickPick();
 					if (variable !== undefined) {
 						editor.insertSnippet(new SnippetString(`\\\$${variable}`), editor.selection);
 					}
@@ -73,7 +73,7 @@ export default function initSnippetFeatureCommands(
 				'snippetstudio.editor.insertVariablePlaceholder',
 				// eslint-disable-next-line no-unused-vars
 				async (editor: TextEditor, edit: TextEditorEdit) => {
-					const variable = await __showVariableQuickPick();
+					const variable = await _showVariableQuickPick();
 					if (variable !== undefined) {
 						editor.insertSnippet(
 							new SnippetString(`\\\${${variable}:\${1:\${TM_SELECTED_TEXT:placeholder}}}$0`),
@@ -89,10 +89,7 @@ export default function initSnippetFeatureCommands(
 				'snippetstudio.editor.insertVariable',
 				// eslint-disable-next-line no-unused-vars
 				async (editor: TextEditor, edit: TextEditorEdit) => {
-					editor.insertSnippet(
-						new SnippetString(`$\${1|${__variableList()}|}$0`),
-						editor.selection
-					);
+					editor.insertSnippet(new SnippetString(`$\${1|${_variableList()}|}$0`), editor.selection);
 				}
 			),
 			registerTextEditorCommand(
@@ -101,7 +98,7 @@ export default function initSnippetFeatureCommands(
 				async (editor: TextEditor, edit: TextEditorEdit) => {
 					editor.insertSnippet(
 						new SnippetString(
-							`\\\${\${1|${__variableList()}|}:\${2:\${TM_SELECTED_TEXT:placeholder}}}$0`
+							`\\\${\${1|${_variableList()}|}:\${2:\${TM_SELECTED_TEXT:placeholder}}}$0`
 						),
 						editor.selection
 					);
@@ -114,7 +111,7 @@ export default function initSnippetFeatureCommands(
 			'snippetstudio.editor.insertPlaceholderWithTranformation',
 			// eslint-disable-next-line no-unused-vars
 			async (editor: TextEditor, edit: TextEditorEdit) => {
-				const featureId = __getNextFeatureNumber(editor);
+				const featureId = _getNextFeatureNumber(editor);
 				editor.insertSnippet(
 					new SnippetString(
 						`\\\${${featureId}/(.*)/\\\${${featureId}:/\${2|capitalize,upcase,downcase,pascalcase,camelcase|}}/}$0`
@@ -162,7 +159,7 @@ export default function initSnippetFeatureCommands(
 					);
 
 					const variable = new CompletionItem('variable', Event);
-					variable.insertText = new SnippetString(`$\${1|${__variableList()}|}$0`);
+					variable.insertText = new SnippetString(`$\${1|${_variableList()}|}$0`);
 					variable.detail = 'variable snippet insertion feature';
 					variable.documentation = new MarkdownString(
 						`With $name, you can insert the value of a variable. When a variable is unknown (that is, its name isn't defined) the name of the variable is inserted and it is transformed into a placeholder. ${source}`
@@ -170,7 +167,7 @@ export default function initSnippetFeatureCommands(
 
 					const variablePlaceholder = new CompletionItem('variablePlaceholder', Event);
 					variablePlaceholder.insertText = new SnippetString(
-						`\\\${\${1|${__variableList()}|}:\${2:\${TM_SELECTED_TEXT:placeholder}}}$0`
+						`\\\${\${1|${_variableList()}|}:\${2:\${TM_SELECTED_TEXT:placeholder}}}$0`
 					);
 					variablePlaceholder.detail = 'variablePlaceholder snippet insertion feature';
 					variablePlaceholder.documentation = new MarkdownString(
@@ -201,7 +198,7 @@ export default function initSnippetFeatureCommands(
 }
 
 /** finds the next unsused insertion feature number from the editor */
-export function __getNextFeatureNumber(editor: TextEditor): string | number {
+export function _getNextFeatureNumber(editor: TextEditor): string | number {
 	const regex = /(?<!\\)\$\{?(\d{1,2})/g;
 	const text = editor.document.getText();
 
@@ -221,12 +218,12 @@ export function __getNextFeatureNumber(editor: TextEditor): string | number {
 }
 
 /** returns a comma delimited list of snippet context variables */
-export function __variableList(): string {
+export function _variableList(): string {
 	return 'TM_SELECTED_TEXT,TM_CURRENT_LINE,TM_CURRENT_WORD,TM_LINE_INDEX,TM_LINE_NUMBER,TM_FILENAME,TM_FILENAME_BASE,TM_DIRECTORY,TM_FILEPATH,RELATIVE_FILEPATH,CLIPBOARD,WORKSPACE_NAME,WORKSPACE_FOLDER,CURSOR_INDEX,CURSOR_NUMBER,CURRENT_YEAR,CURRENT_YEAR_SHORT,CURRENT_MONTH,CURRENT_MONTH_NAME,CURRENT_MONTH_NAME_SHORT,CURRENT_DATE,CURRENT_DAY_NAME,CURRENT_DAY_NAME_SHORT,CURRENT_HOUR,CURRENT_MINUTE,CURRENT_SECOND,CURRENT_SECONDS_UNIX,CURRENT_TIMEZONE_OFFSET,RANDOM,RANDOM_HEX,UUID,BLOCK_COMMENT_START,BLOCK_COMMENT_END,LINE_COMMENT';
 }
 
 /** choose a variable from a quick pick */
-export async function __showVariableQuickPick(): Promise<string | undefined> {
+export async function _showVariableQuickPick(): Promise<string | undefined> {
 	const variables = [
 		// TextMate Variables
 		{

--- a/src/ui/editor/startEditor.test.ts
+++ b/src/ui/editor/startEditor.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import {
-	__escapeAllSnippetInsertionFeatures,
-	__initEditing,
-	__newSnippetEditorUri,
+	_escapeAllSnippetInsertionFeatures,
+	_initEditing,
+	_newSnippetEditorUri,
 	editSnippet,
 } from './startEditor';
 import {
@@ -21,7 +21,7 @@ vi.mock('./startEditor', async () => {
 
 	return {
 		...actual,
-		__initEditing: vi.fn().mockResolvedValue({
+		_initEditing: vi.fn().mockResolvedValue({
 			mountSnippet: vi.fn(),
 			delete: vi.fn(),
 		}),
@@ -104,7 +104,7 @@ describe('startEditor', () => {
 			const result = await editSnippet(context, 'typescript', mockSnippetData, '');
 
 			expect(createFile).toHaveBeenCalledWith(mockSnippetData.filename, false);
-			expect(__initEditing).not.toHaveBeenCalled();
+			expect(_initEditing).not.toHaveBeenCalled();
 			expect(result).toBeUndefined();
 		});
 
@@ -124,26 +124,26 @@ describe('startEditor', () => {
 			const startText = '() => $0 < $1';
 			const endText = '() => \\$0 < \\$1';
 
-			expect(__escapeAllSnippetInsertionFeatures(startText)).toBe(endText);
+			expect(_escapeAllSnippetInsertionFeatures(startText)).toBe(endText);
 		});
 		it("should escape placeholders that aren't placeholders", () => {
 			const startText = 'my ${1:computer} is cool';
 			const endText = 'my \\${1:computer} is cool';
 
-			expect(__escapeAllSnippetInsertionFeatures(startText)).toBe(endText);
+			expect(_escapeAllSnippetInsertionFeatures(startText)).toBe(endText);
 		});
 	});
 
 	describe('newSnippetEditorUri', () => {
 		it('should return a Uri', async () => {
-			const uri = __newSnippetEditorUri();
+			const uri = _newSnippetEditorUri();
 			expect(uri).toSatisfy(
 				({ scheme, path }) => scheme === 'snippetstudio' && path.includes('/snippets/snippet')
 			);
 		});
 		it('should return a new Uri every time', async () => {
-			const uri1 = __newSnippetEditorUri();
-			const uri2 = __newSnippetEditorUri();
+			const uri1 = _newSnippetEditorUri();
+			const uri2 = _newSnippetEditorUri();
 
 			expect(uri1.path).not.toBe(uri2.path);
 		});

--- a/src/ui/editor/startEditor.ts
+++ b/src/ui/editor/startEditor.ts
@@ -21,7 +21,7 @@ import type { SnippetData } from '../../types';
 let snippetEditorProvider: SnippetEditorProvider | undefined;
 
 /** completes all setup of editor, snippet data view, and commands */
-export async function __initEditing(context: ExtensionContext): Promise<SnippetEditorProvider> {
+export async function _initEditing(context: ExtensionContext): Promise<SnippetEditorProvider> {
 	if (!snippetEditorProvider) {
 		const snippetDataManager = new SnippetDataManager();
 		const snippetDataView = new SnippetDataWebViewProvider(context, snippetDataManager);
@@ -56,13 +56,13 @@ async function editSnippet(
 				return;
 			}
 		}
-		const provider = await __initEditing(context);
+		const provider = await _initEditing(context);
 		if (
 			getConfiguration('snippetstudio').get<boolean>('editor.autoEscapeDollarSignsFromSelection')
 		) {
-			body = __escapeAllSnippetInsertionFeatures(body);
+			body = _escapeAllSnippetInsertionFeatures(body);
 		}
-		const uri = __newSnippetEditorUri(
+		const uri = _newSnippetEditorUri(
 			langId,
 			path.extname(snippetData.filename) === '.code-snippets'
 		);
@@ -88,7 +88,7 @@ async function editSnippet(
 let editorCount = 0;
 
 /** create a new editor uri */
-export function __newSnippetEditorUri(
+export function _newSnippetEditorUri(
 	langId: string = 'plaintext',
 	showScope: boolean = true
 ): UriType {
@@ -100,7 +100,7 @@ export function __newSnippetEditorUri(
 }
 
 /** Escapes all instances of placholders and tabstops */
-export function __escapeAllSnippetInsertionFeatures(str: string): string {
+export function _escapeAllSnippetInsertionFeatures(str: string): string {
 	// Escape tabstops
 	let escapedString = str.replace(/\$(\d+)/g, '\\$$$1');
 

--- a/src/ui/syntax/index.test.ts
+++ b/src/ui/syntax/index.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
 import type { TextDocument, TextEditor } from 'vscode';
 import vscode, { createTextEditorDecorationType, getConfiguration, Range } from '../../vscode';
-import { highlightSnippetInsertionFeatures, __moveRangeDown } from '.';
+import { highlightSnippetInsertionFeatures, _moveRangeDown } from '.';
 
 const expectedDecoration = createTextEditorDecorationType({});
 const expectedLocation = expect.anything();
@@ -66,11 +66,11 @@ describe('syntax', () => {
 		});
 	});
 
-	describe('__moveLocationDown', () => {
+	describe('moveRangeDown', () => {
 		it('should move a Location down one line', () => {
 			(editor.document.lineAt as Mock).mockReturnValue({ text: 'placeholder text' });
 			const range = new Range(0, 5, 0, 10);
-			const newLocation = __moveRangeDown(range, editor.document);
+			const newLocation = _moveRangeDown(range, editor.document);
 
 			expect(newLocation.start.line).toBe(1);
 			expect(newLocation.end.line).toBe(1);

--- a/src/ui/syntax/index.ts
+++ b/src/ui/syntax/index.ts
@@ -52,7 +52,7 @@ export function highlightSnippetInsertionFeatures(editor: TextEditor) {
 			?.filter((dg) => dg.range.intersection(range))
 			.forEach((dg) => {
 				supressedDiagnostics.push({ range: dg.range });
-				supressedDiagnosticsOverLine.push({ range: __moveRangeDown(dg.range, document) });
+				supressedDiagnosticsOverLine.push({ range: _moveRangeDown(dg.range, document) });
 				diagnostics.splice(diagnostics.indexOf(dg), 1);
 			});
 	}
@@ -65,7 +65,7 @@ export function highlightSnippetInsertionFeatures(editor: TextEditor) {
 }
 
 /** moves a vscode range down a line and shrinks it to fit the textdocument */
-export function __moveRangeDown(range: RangeType, document: TextDocument): RangeType {
+export function _moveRangeDown(range: RangeType, document: TextDocument): RangeType {
 	const newStartLine = Math.min(range.start.line + 1, document.lineCount - 1);
 	const newEndLine = Math.min(range.end.line + 1, document.lineCount - 1);
 

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -5,9 +5,9 @@ import { readJsonC } from './jsoncFilesIO';
 import vscode, { showErrorMessage } from '../vscode';
 import {
 	getUserPath,
-	__readGlobalStorage,
+	_readGlobalStorage,
 	initGlobalStore,
-	__initUserPath,
+	_initUserPath,
 	getExtensionContext,
 } from './context';
 import { context } from '../../.vitest/__mocks__/shared';
@@ -126,7 +126,7 @@ describe('context', () => {
 				'Code',
 				'User'
 			);
-			const userPath = __initUserPath();
+			const userPath = _initUserPath();
 			expect(userPath).toBe(expectedPath);
 		});
 
@@ -134,7 +134,7 @@ describe('context', () => {
 			Object.defineProperty(process, 'platform', {
 				value: 'sunos',
 			});
-			const userPath = __initUserPath();
+			const userPath = _initUserPath();
 			expect(showErrorMessage).toHaveBeenCalledWith(
 				`Unsupported platform: sunos. Couldn't find default user path. Want to submit an issue to request support for your device?`,
 				'Open GitHub Issue'
@@ -192,12 +192,12 @@ describe('context', () => {
 			Object.defineProperty(process, 'platform', {
 				value: 'darwin',
 			});
-			const userPath = __initUserPath();
+			const userPath = _initUserPath();
 			const expectedPath = path.join(userPath!, 'globalStorage', 'storage.json');
 			const mockStorage = { userDataProfiles: [] };
 			(readJsonC as Mock).mockResolvedValue(mockStorage);
 
-			const result = await __readGlobalStorage();
+			const result = await _readGlobalStorage();
 
 			expect(readJsonC).toHaveBeenCalledWith(expectedPath);
 			expect(result).toBe(mockStorage);
@@ -208,7 +208,7 @@ describe('context', () => {
 				value: 'sunos',
 			});
 
-			const result = await __readGlobalStorage();
+			const result = await _readGlobalStorage();
 
 			expect(readJsonC).not.toHaveBeenCalled();
 			expect(result).toBeUndefined();

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -21,7 +21,7 @@ export async function getExtensionContext(): Promise<ExtensionContext> {
  */
 export async function initGlobalStore(context: ExtensionContext): Promise<boolean> {
 	extensionContext = context;
-	const storage = await __readGlobalStorage();
+	const storage = await _readGlobalStorage();
 	if (storage) {
 		context.globalState.update('users', storage.userDataProfiles ?? []);
 		context.globalState.update('profileAssociations', storage.profileAssociations);
@@ -30,8 +30,8 @@ export async function initGlobalStore(context: ExtensionContext): Promise<boolea
 }
 
 /** Reads the globalStorage/storage.json VS Code storage file */
-export async function __readGlobalStorage(): Promise<GlobalStorage | undefined> {
-	const userPath = __initUserPath();
+export async function _readGlobalStorage(): Promise<GlobalStorage | undefined> {
+	const userPath = _initUserPath();
 	if (userPath) {
 		const globalStoragePath = path.join(userPath, 'globalStorage', 'storage.json');
 		return (await readJsonC(globalStoragePath)) as GlobalStorage;
@@ -39,7 +39,7 @@ export async function __readGlobalStorage(): Promise<GlobalStorage | undefined> 
 }
 
 /** handles if a user path doesn't exist */
-export function __initUserPath(): string | undefined {
+export function _initUserPath(): string | undefined {
 	try {
 		const userPath = getUserPath();
 		return userPath;


### PR DESCRIPTION
<!-- Use conventional commit in title -->
<!-- <type>(<scope (optional)>): <description> -->
<!-- ie feat(a11y): fixed contrast errors for light mode -->
<!-- See https://www.conventionalcommits.org/en/v1.0.0/ -->

Adds missing unit tests for locate snippet file functions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved snippet discovery and grouping for global, language-specific, and workspace snippets for more reliable snippet access.
  * Safer editor range handling when moving ranges down — character positions are now clamped to valid line lengths.

* **Tests**
  * Expanded test coverage and shared test scaffolding to validate global snippet discovery and snippet-location behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->