### PR TITLE
fix: if scope is omitted, snippets are treated as global

### DIFF
--- a/public/snippetData.html
+++ b/public/snippetData.html
@@ -42,7 +42,7 @@
 				const desc = formData.get('description');
 				if (desc) data.description = desc;
 				const scope = formData.get('scope');
-				if (showScope && scope) data.scope = scope;
+				if (showScope) data.scope = scope || "global";
 
 				vscode.postMessage({ command: 'updateSnippetData', data: data });
 			});

--- a/src/snippets/updateSnippets.ts
+++ b/src/snippets/updateSnippets.ts
@@ -31,11 +31,9 @@ async function writeSnippet(filepath: string, titleKey: string, snippet: VSCodeS
 		return;
 	}
 
-	if (snippet.scope) {
-		if (path.extname(filepath) === '.json') {
-			delete snippet.scope;
-		}
-	} else if (path.extname(filepath) === '.code-snippets') {
+	if (path.extname(filepath) === '.json' || snippet.scope === 'global') {
+		delete snippet.scope;
+	} else if (!snippet.scope) {
 		snippet.scope = getCurrentLanguage() ?? 'plaintext';
 	}
 
@@ -94,6 +92,9 @@ async function moveSnippet(item: TreePathItem) {
 	}
 
 	const snippet = (await readSnippet(item.path, item.description as string)) as VSCodeSnippet;
+	if (path.extname(item.path) === '.code-snippets' && !snippet.scope) {
+		snippet.scope = 'global';
+	}
 
 	await Promise.all([
 		writeSnippet(selected.description, item.description as string, snippet),


### PR DESCRIPTION
<!-- Use conventional commit in title -->
<!-- <type>(<scope (optional)>): <description> -->
<!-- ie feat(a11y): fixed contrast errors for light mode -->
<!-- See https://www.conventionalcommits.org/en/v1.0.0/ -->

## Summary

<!-- Optional: Link related issue(s) -->
Issue #15 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed scope assignment logic to consistently apply default "global" scope when scope values are missing but enabled
  - Improved snippet scope handling across file formats to ensure proper default values (current language or 'plaintext') are applied uniformly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->