### PR TITLE
feat: add refresh command to reload shell snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,12 @@
 				"category": "snippetstudio"
 			},
 			{
+				"command": "snippetstudio.shell.refresh",
+				"title": "Refresh Shell Snippets",
+				"icon": "$(refresh)",
+				"category": "snippetstudio"
+			},
+			{
 				"command": "snippetstudio.file.createGlobalLang",
 				"title": "Create Global Snippets File",
 				"icon": "$(file-code)",
@@ -447,6 +453,11 @@
 				{
 					"command": "snippetstudio.refreshLocations",
 					"when": "view == location-manager",
+					"group": "navigation"
+				},
+				{
+					"command": "snippetstudio.shell.refresh",
+					"when": "view == shell-snippets",
 					"group": "navigation"
 				},
 				{

--- a/src/ui/shell/commands.test.ts
+++ b/src/ui/shell/commands.test.ts
@@ -17,13 +17,16 @@ describe('initSnippetShellCommands', () => {
 		const spy = vi.spyOn(context.subscriptions, 'push');
 		await initSnippetShellCommands(context);
 		expect(spy).toBeCalled();
-		expect(registerCommand).toBeCalledTimes(4);
+		expect(registerCommand).toBeCalledTimes(5);
 	});
 
 	it("should lazy load the view logic if there's snippets", async () => {
 		await initSnippetShellCommands(context);
 		expect(getShellView).not.toBeCalled();
-		(getShellSnippets as Mock).mockReturnValue([[{ command: 'echo "Hello"', runImmediately: false, profile: 'bash' }], []]);
+		(getShellSnippets as Mock).mockReturnValue([
+			[{ command: 'echo "Hello"', runImmediately: false, profile: 'bash' }],
+			[],
+		]);
 		await initSnippetShellCommands(context);
 		expect(getShellView).toBeCalled();
 	});

--- a/src/ui/shell/commands.ts
+++ b/src/ui/shell/commands.ts
@@ -21,6 +21,10 @@ export async function initSnippetShellCommands(context: ExtensionContext) {
 		registerCommand('snippetstudio.shell.run', async (item: ShellTreeItem) => {
 			const { runShellSnippet } = await import('./handlers.js');
 			runShellSnippet(item);
+		}),
+		registerCommand('snippetstudio.shell.refresh', async () => {
+			const { getShellView } = await import('./ShellViewProvider.js');
+			getShellView().refresh();
 		})
 	);
 


### PR DESCRIPTION
<!-- Use conventional commit in title -->
<!-- <type>(<scope (optional)>): <description> -->
<!-- ie feat(a11y): fixed contrast errors for light mode -->
<!-- See https://www.conventionalcommits.org/en/v1.0.0/ -->

## Summary

<!-- Optional: Link related issue(s) -->
Issue #50 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refresh button to the Shell Snippets view, enabling users to manually refresh shell snippets without reloading the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->