### PR TITLE
feat: shell create command can be triggered from shell dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -611,6 +611,11 @@
 					"command": "snippetstudio.shell.run",
 					"group": "inline",
 					"when": "viewItem == shell-snippet"
+				},
+				{
+					"command": "snippetstudio.shell.create",
+					"group": "inline",
+					"when": "viewItem == shell-dropdown"
 				}
 			]
 		},

--- a/src/ui/shell/ShellViewProvider.ts
+++ b/src/ui/shell/ShellViewProvider.ts
@@ -29,11 +29,12 @@ export class ShellTreeItem extends TreeItem {
 }
 
 /** Constructs a dropdown to organize shell items */
-class ShellTreeDropdown extends TreeItem {
+export class ShellTreeDropdown extends TreeItem {
 	constructor(
 		public readonly label: string,
 		public readonly hasItems: boolean,
-		public readonly icon: string
+		public readonly icon: string,
+		public readonly isLocal: boolean
 	) {
 		super(label, hasItems ? Expanded : None);
 		(this as any).iconPath = new ThemeIcon(icon);
@@ -69,8 +70,18 @@ class ShellViewProvider implements TreeDataProvider<TreeItemType> {
 			return this.localItems;
 		}
 		return [
-			new ShellTreeDropdown('Global Shell Snippets', Boolean(this.globalItems.length), 'globe'),
-			new ShellTreeDropdown('Local Shell Snippets', Boolean(this.localItems.length), 'folder'),
+			new ShellTreeDropdown(
+				'Global Shell Snippets',
+				Boolean(this.globalItems.length),
+				'globe',
+				true
+			),
+			new ShellTreeDropdown(
+				'Local Shell Snippets',
+				Boolean(this.localItems.length),
+				'folder',
+				false
+			),
 		];
 	}
 

--- a/src/ui/shell/commands.ts
+++ b/src/ui/shell/commands.ts
@@ -1,14 +1,14 @@
 import type { ExtensionContext } from 'vscode';
-import type { ShellTreeItem } from './ShellViewProvider';
+import type { ShellTreeDropdown, ShellTreeItem } from './ShellViewProvider';
 import { registerCommand } from '../../vscode';
 import { getShellSnippets } from './config';
 
 /** Registers and lazy loads all shell snippet commands */
 export async function initSnippetShellCommands(context: ExtensionContext) {
 	context.subscriptions.push(
-		registerCommand('snippetstudio.shell.create', async () => {
+		registerCommand('snippetstudio.shell.create', async (item: ShellTreeDropdown) => {
 			const { createShellSnippet } = await import('./handlers.js');
-			createShellSnippet();
+			createShellSnippet(item);
 		}),
 		registerCommand('snippetstudio.shell.edit', async (item: ShellTreeItem) => {
 			const { editShellSnippet } = await import('./handlers.js');

--- a/src/ui/shell/handlers.ts
+++ b/src/ui/shell/handlers.ts
@@ -13,7 +13,7 @@ import vscode, {
 	createQuickPick,
 	showWarningMessage,
 } from '../../vscode';
-import { getShellView, type ShellTreeItem } from './ShellViewProvider';
+import { getShellView, type ShellTreeDropdown, type ShellTreeItem } from './ShellViewProvider';
 import { getShellSnippets, setShellSnippets } from './config';
 import { getConfirmation } from '../../utils/user';
 import { findInactiveTerminal, getAllShellProfiles, getDefaultShellProfile } from './utils';
@@ -100,7 +100,7 @@ export async function runShellSnippet(item: ShellTreeItem) {
 }
 
 /** Command handler to create a new shell snippet */
-export async function createShellSnippet() {
+export async function createShellSnippet(item: ShellTreeDropdown) {
 	const command = await getCommand();
 
 	if (!command) {
@@ -136,7 +136,9 @@ export async function createShellSnippet() {
 	const prePick = options.find(
 		({ id, label }) => id === 'profile' && label === defaultProfile
 	) as Item;
-	qp.selectedItems = [options[1], prePick];
+	const preselectedOptions = [options[1], prePick];
+	if (item?.isLocal === false) preselectedOptions.push(options[2]);
+	qp.selectedItems = preselectedOptions;
 
 	qp.show();
 


### PR DESCRIPTION
<!-- Use conventional commit in title -->
<!-- <type>(<scope (optional)>): <description> -->
<!-- ie feat(a11y): fixed contrast errors for light mode -->
<!-- See https://www.conventionalcommits.org/en/v1.0.0/ -->

## Summary

<!-- Optional: Link related issue(s) -->
Issue #52 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Create" context menu option for shell dropdown items to create snippets directly from the shell view.

* **Improvements**
  * Snippet creation now receives the selected shell item and preselects workspace-only options for non-local shells, improving handling of local vs. global shell contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->