### PR TITLE
fix: snippet uses the correct language when edit from location view

### DIFF
--- a/src/utils/language.ts
+++ b/src/utils/language.ts
@@ -1,8 +1,8 @@
 import vscode, { showQuickPick, getLanguages } from '../vscode';
 
 /** Prompts the user to select a language */
-async function selectLanguage(): Promise<string | undefined> {
-	return await showQuickPick(await getLanguages(), {
+async function selectLanguage(options?: string[]): Promise<string | undefined> {
+	return await showQuickPick(options ?? (await getLanguages()), {
 		placeHolder: 'Select a language',
 		canPickMany: false,
 	});


### PR DESCRIPTION


<!-- Use conventional commit in title -->
<!-- <type>(<scope (optional)>): <description> -->
<!-- ie feat(a11y): fixed contrast errors for light mode -->
<!-- See https://www.conventionalcommits.org/en/v1.0.0/ -->

## Summary

<!-- Optional: Link related issue(s) -->
Issue #90 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection when editing snippets using scope metadata with better fallback options.

* **Chores**
  * Updated snippet file storage format to use .code-snippets extension.
  * Refactored language selection logic for more flexible configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->